### PR TITLE
Adding logic for enabling and disabling radio buttons

### DIFF
--- a/src/Forms/AzureMigrateExportMainForm.cs
+++ b/src/Forms/AzureMigrateExportMainForm.cs
@@ -26,7 +26,7 @@ namespace Azure.Migrate.Export.Forms
         public AzureMigrateExportMainForm()
         {
             InitializeComponent();
-            ProjectDetailsFormObj = new ProjectDetailsForm(this);  
+            ProjectDetailsFormObj = new ProjectDetailsForm(this);
 
             ConfigurationFormObj = new ConfigurationForm(this);
             ConfigurationFormObj.SetDefaultConfigurationValues();

--- a/src/Forms/AzureMigrateExportMainForm.cs
+++ b/src/Forms/AzureMigrateExportMainForm.cs
@@ -20,11 +20,13 @@ namespace Azure.Migrate.Export.Forms
 
         private Button CurrentButtonTab = null;
         private Form CurrentlyActiveForm = null;
+        private bool HasImportInventory = false;
+        private bool HasApplianceInventory = false;
 
         public AzureMigrateExportMainForm()
         {
             InitializeComponent();
-            ProjectDetailsFormObj = new ProjectDetailsForm(this);
+            ProjectDetailsFormObj = new ProjectDetailsForm(this);  
 
             ConfigurationFormObj = new ConfigurationForm(this);
             ConfigurationFormObj.SetDefaultConfigurationValues();
@@ -60,7 +62,10 @@ namespace Azure.Migrate.Export.Forms
         private void NextButton_Click(object sender, EventArgs e)
         {
             if (CurrentButtonTab == ProjectDetailsTabButton)
+            {
+                ConfigurationFormObj.SetDefaultConfigurationValues();
                 HandleTabChange(ConfigurationFormObj, ConfigurationTabButton);
+            }
             else if (CurrentButtonTab == ConfigurationTabButton)
                 HandleTabChange(AssessmentSettingsFormObj, AssessmentSettingsTabButton);
         }
@@ -934,6 +939,25 @@ namespace Azure.Migrate.Export.Forms
             AssessmentSettingsFormObj.InitializeCurrencyComboBox();
             AssessmentSettingsFormObj.InitializeTargetRegionComboBox();
             AssessmentSettingsFormObj.EnableAssessmentDurationComboBox();
+        }
+
+        public void SetHasImportInventory(bool hasImportInventory)
+        {
+            HasImportInventory = hasImportInventory;
+        }
+
+        public void SetHasApplianceInventory(bool hasApplianceInventory)
+        {
+            HasApplianceInventory = hasApplianceInventory;
+        }
+         public bool GetHasImportInventory()
+        {
+            return HasImportInventory;
+        }
+
+        public bool GetHasApplianceInventory() 
+        {
+            return HasApplianceInventory;
         }
         #endregion
     }

--- a/src/Forms/ConfigurationForm.cs
+++ b/src/Forms/ConfigurationForm.cs
@@ -39,11 +39,11 @@ namespace Azure.Migrate.Export.Forms
                 ApplianceRadioButton.Enabled = true;
                 ApplianceRadioButton.Checked = false;
                 VMwareCheckBox.Enabled = true;
-                VMwareCheckBox.Checked = true;
+                VMwareCheckBox.Checked = false;
                 HyperVCheckBox.Enabled = true;
-                HyperVCheckBox.Checked = true;
+                HyperVCheckBox.Checked = false;
                 PhysicalCheckBox.Enabled = true;
-                PhysicalCheckBox.Checked = true;
+                PhysicalCheckBox.Checked = false;
             }
             else
             {

--- a/src/Forms/ConfigurationForm.cs
+++ b/src/Forms/ConfigurationForm.cs
@@ -37,13 +37,13 @@ namespace Azure.Migrate.Export.Forms
             if (mainFormObj.GetHasApplianceInventory())
             {
                 ApplianceRadioButton.Enabled = true;
-                ApplianceRadioButton.Checked = false;
+                ApplianceRadioButton.Checked = true;
                 VMwareCheckBox.Enabled = true;
-                VMwareCheckBox.Checked = false;
+                VMwareCheckBox.Checked = true;
                 HyperVCheckBox.Enabled = true;
-                HyperVCheckBox.Checked = false;
+                HyperVCheckBox.Checked = true;
                 PhysicalCheckBox.Enabled = true;
-                PhysicalCheckBox.Checked = false;
+                PhysicalCheckBox.Checked = true;
             }
             else
             {

--- a/src/Forms/ConfigurationForm.cs
+++ b/src/Forms/ConfigurationForm.cs
@@ -24,10 +24,38 @@ namespace Azure.Migrate.Export.Forms
         #region Set Default Values
         public void SetDefaultConfigurationValues()
         {
-            ApplianceRadioButton.Checked = true;
-            VMwareCheckBox.Checked = true;
-            HyperVCheckBox.Checked = true;
-            PhysicalCheckBox.Checked = true;
+            if (mainFormObj.GetHasImportInventory())
+            {
+                ImportRadioButton.Enabled = true;
+                ImportRadioButton.Checked = false;
+            }
+            else
+            {
+                ImportRadioButton.Enabled = false;
+                ImportRadioButton.Checked = false;
+            }
+            if (mainFormObj.GetHasApplianceInventory())
+            {
+                ApplianceRadioButton.Enabled = true;
+                ApplianceRadioButton.Checked = false;
+                VMwareCheckBox.Enabled = true;
+                VMwareCheckBox.Checked = true;
+                HyperVCheckBox.Enabled = true;
+                HyperVCheckBox.Checked = true;
+                PhysicalCheckBox.Enabled = true;
+                PhysicalCheckBox.Checked = true;
+            }
+            else
+            {
+                ApplianceRadioButton.Enabled = false;
+                ApplianceRadioButton.Checked = false;
+                VMwareCheckBox.Enabled = false;
+                VMwareCheckBox.Checked = false;
+                HyperVCheckBox.Enabled = false;
+                HyperVCheckBox.Checked = false;
+                PhysicalCheckBox.Enabled = false;
+                PhysicalCheckBox.Checked = false;
+            }
 
             ExpressWorkflowRadioButton.Checked = true;
             ComprehensiveProposalRadioButton.Checked = true;

--- a/src/Forms/ProjectDetailsForm.Designer.cs
+++ b/src/Forms/ProjectDetailsForm.Designer.cs
@@ -32,8 +32,7 @@
             this.AzureMigrateProjectDetailsGroupBox = new System.Windows.Forms.GroupBox();
             this.TenantIdInfoLabel = new System.Windows.Forms.Label();
             this.AzureMigrateProjectNameInfoLabel = new System.Windows.Forms.Label();
-            this.AssessmentProjectNameInfoLabel = new System.Windows.Forms.Label();
-            this.DiscoverySiteNameInfoLabel = new System.Windows.Forms.Label();
+            this.SiteDiscoveryStatusInfoLabel = new System.Windows.Forms.Label();
             this.ResourceGroupNameInfoLabel = new System.Windows.Forms.Label();
             this.SubscriptionInfoLabel = new System.Windows.Forms.Label();
             this.AzureMigrateProjectNameComboBox = new System.Windows.Forms.ComboBox();
@@ -55,8 +54,7 @@
             // 
             this.AzureMigrateProjectDetailsGroupBox.Controls.Add(this.TenantIdInfoLabel);
             this.AzureMigrateProjectDetailsGroupBox.Controls.Add(this.AzureMigrateProjectNameInfoLabel);
-            this.AzureMigrateProjectDetailsGroupBox.Controls.Add(this.AssessmentProjectNameInfoLabel);
-            this.AzureMigrateProjectDetailsGroupBox.Controls.Add(this.DiscoverySiteNameInfoLabel);
+            this.AzureMigrateProjectDetailsGroupBox.Controls.Add(this.SiteDiscoveryStatusInfoLabel);
             this.AzureMigrateProjectDetailsGroupBox.Controls.Add(this.ResourceGroupNameInfoLabel);
             this.AzureMigrateProjectDetailsGroupBox.Controls.Add(this.SubscriptionInfoLabel);
             this.AzureMigrateProjectDetailsGroupBox.Controls.Add(this.AzureMigrateProjectNameComboBox);
@@ -83,15 +81,10 @@
             resources.ApplyResources(this.AzureMigrateProjectNameInfoLabel, "AzureMigrateProjectNameInfoLabel");
             this.AzureMigrateProjectNameInfoLabel.Name = "AzureMigrateProjectNameInfoLabel";
             // 
-            // AssessmentProjectNameInfoLabel
+            // SiteDiscoveryStatusInfoLabel
             // 
-            resources.ApplyResources(this.AssessmentProjectNameInfoLabel, "AssessmentProjectNameInfoLabel");
-            this.AssessmentProjectNameInfoLabel.Name = "AssessmentProjectNameInfoLabel";
-            // 
-            // DiscoverySiteNameInfoLabel
-            // 
-            resources.ApplyResources(this.DiscoverySiteNameInfoLabel, "DiscoverySiteNameInfoLabel");
-            this.DiscoverySiteNameInfoLabel.Name = "DiscoverySiteNameInfoLabel";
+            resources.ApplyResources(this.SiteDiscoveryStatusInfoLabel, "SiteDiscoveryStatusInfoLabel");
+            this.SiteDiscoveryStatusInfoLabel.Name = "SiteDiscoveryStatusInfoLabel";
             // 
             // ResourceGroupNameInfoLabel
             // 
@@ -221,8 +214,7 @@
         private System.Windows.Forms.RichTextBox ProjectDetailsDescriptionRichTextBox;
         private System.Windows.Forms.Label SubscriptionInfoLabel;
         private System.Windows.Forms.Label ResourceGroupNameInfoLabel;
-        private System.Windows.Forms.Label DiscoverySiteNameInfoLabel;
-        private System.Windows.Forms.Label AssessmentProjectNameInfoLabel;
+        private System.Windows.Forms.Label SiteDiscoveryStatusInfoLabel;
         private System.Windows.Forms.Label AzureMigrateProjectNameInfoLabel;
         private System.Windows.Forms.Label TenantIdInfoLabel;
     }

--- a/src/Forms/ProjectDetailsForm.cs
+++ b/src/Forms/ProjectDetailsForm.cs
@@ -308,10 +308,10 @@ namespace Azure.Migrate.Export.Forms
                                        Routes.QueryStringQuestionMark + Routes.QueryParameterApiVersion + Routes.QueryStringEquals +
                                        Routes.MasterSiteApiVersion;
                         var responseSites = (await httpClientHelperObj.GetProjectDetailsHttpJsonResponse(sitesUrl))["properties"]["sites"];
-                        bool hasVmware = responseSites.Any(site => site.ToString().Contains("vmwaresites"));
-                        bool hasHyperV = responseSites.Any(site => site.ToString().Contains("hypervsites"));
-                        bool hasPhysical = responseSites.Any(site => site.ToString().Contains("serversites"));
-                        bool hasImport = responseSites.Any(site => site.ToString().Contains("importsites"));
+                        bool hasVmware = responseSites.Any(site => site.ToString().ToLower().Contains("vmwaresites"));
+                        bool hasHyperV = responseSites.Any(site => site.ToString().ToLower().Contains("hypervsites"));
+                        bool hasPhysical = responseSites.Any(site => site.ToString().ToLower().Contains("serversites"));
+                        bool hasImport = responseSites.Any(site => site.ToString().ToLower().Contains("importsites"));
                         mainFormObj.SetHasApplianceInventory(hasVmware || hasHyperV || hasPhysical);
                         mainFormObj.SetHasImportInventory(hasImport);
                         if (!hasVmware && !hasHyperV && !hasPhysical && !hasImport)

--- a/src/Forms/ProjectDetailsForm.cs
+++ b/src/Forms/ProjectDetailsForm.cs
@@ -283,7 +283,7 @@ namespace Azure.Migrate.Export.Forms
                 return;
             }
 
-            DiscoverySiteNameInfoLabel.Text = "";
+            SiteDiscoveryStatusInfoLabel.Text = "Fetching inventory data";
             HttpClientHelper httpClientHelperObj = new HttpClientHelper();
 
             string url = Routes.ProtocolScheme + Routes.AzureManagementApiHostname + Routes.ForwardSlash +
@@ -304,7 +304,21 @@ namespace Azure.Migrate.Export.Forms
                     if (masterSiteIdContents.Count > 0)
                     {
                         DiscoverySiteName = masterSiteIdContents[masterSiteIdContents.Count - 1];
-                        DiscoverySiteNameInfoLabel.Text = DiscoverySiteName;
+                        var sitesUrl = Routes.ProtocolScheme + Routes.AzureManagementApiHostname + masterSiteId +
+                                       Routes.QueryStringQuestionMark + Routes.QueryParameterApiVersion + Routes.QueryStringEquals +
+                                       Routes.MasterSiteApiVersion;
+                        var responseSites = (await httpClientHelperObj.GetProjectDetailsHttpJsonResponse(sitesUrl))["properties"]["sites"];
+                        bool hasVmware = responseSites.Any(site => site.ToString().Contains("vmwaresites"));
+                        bool hasHyperV = responseSites.Any(site => site.ToString().Contains("hypervsites"));
+                        bool hasPhysical = responseSites.Any(site => site.ToString().Contains("serversites"));
+                        bool hasImport = responseSites.Any(site => site.ToString().Contains("importsites"));
+                        mainFormObj.SetHasApplianceInventory(hasVmware || hasHyperV || hasPhysical);
+                        mainFormObj.SetHasImportInventory(hasImport);
+                        if (!hasVmware && !hasHyperV && !hasPhysical && !hasImport)
+                        {
+                            MessageBox.Show("No discovery data was found. Discover your on-premises inventory to proceed ahead");
+                            mainFormObj.CloseForm();
+                        }
                     }
                     else
                         throw new Exception("masterSiteId response in json does not contain enough elements");
@@ -341,7 +355,6 @@ namespace Azure.Migrate.Export.Forms
                 return;
             }
 
-            AssessmentProjectNameInfoLabel.Text = "";
             HttpClientHelper httpClientHelperObj = new HttpClientHelper();
 
             string url = Routes.ProtocolScheme + Routes.AzureManagementApiHostname + Routes.ForwardSlash +
@@ -361,8 +374,8 @@ namespace Azure.Migrate.Export.Forms
                     var projectIdContents = projectId.Split('/').ToList();
                     if (projectIdContents.Count > 0)
                     {
-                        AssessmentProjectName = projectIdContents[projectIdContents.Count - 1];
-                        AssessmentProjectNameInfoLabel.Text = AssessmentProjectName;
+                        AssessmentProjectName = projectIdContents[projectIdContents.Count - 1];                        
+                        SiteDiscoveryStatusInfoLabel.Text = "Inventory data fetched successfully";
                     }
                     else
                         throw new Exception("projectId response in json does not contain enough elements");
@@ -491,10 +504,9 @@ namespace Azure.Migrate.Export.Forms
             AzureMigrateProjectNameInfoLabel.Text = "";
 
             DiscoverySiteName = null;
-            DiscoverySiteNameInfoLabel.Text = "";
+            SiteDiscoveryStatusInfoLabel.Text = "";
 
             AssessmentProjectName = null;
-            AssessmentProjectNameInfoLabel.Text = "";
 
             mainFormObj.MakeProjectDetailsActionButtonEnableDecision();
             mainFormObj.MakeProjectDetailsTabButtonEnableDecision();
@@ -557,10 +569,9 @@ namespace Azure.Migrate.Export.Forms
             AzureMigrateProjectNameInfoLabel.Text = "";
 
             DiscoverySiteName = null;
-            DiscoverySiteNameInfoLabel.Text = "";
+            SiteDiscoveryStatusInfoLabel.Text = "";
 
             AssessmentProjectName = null;
-            AssessmentProjectNameInfoLabel.Text = "";
 
             this.ActiveControl = null;
 
@@ -577,10 +588,9 @@ namespace Azure.Migrate.Export.Forms
             AzureMigrateProjectNameInfoLabel.Text = "";
 
             DiscoverySiteName = null;
-            DiscoverySiteNameInfoLabel.Text = "";
+            SiteDiscoveryStatusInfoLabel.Text = "";
 
             AssessmentProjectName = null;
-            AssessmentProjectNameInfoLabel.Text = "";
 
             this.ActiveControl = null;
 
@@ -593,10 +603,9 @@ namespace Azure.Migrate.Export.Forms
         private async void AzureMigrateProjectNameComboBox_SelectionChangeCommitted(object sender, EventArgs e)
         {
             DiscoverySiteName = null;
-            DiscoverySiteNameInfoLabel.Text = "";
+            SiteDiscoveryStatusInfoLabel.Text = "";
 
             AssessmentProjectName = null;
-            AssessmentProjectNameInfoLabel.Text = "";
 
             this.ActiveControl = null;
 

--- a/src/Forms/ProjectDetailsForm.cs
+++ b/src/Forms/ProjectDetailsForm.cs
@@ -374,7 +374,7 @@ namespace Azure.Migrate.Export.Forms
                     var projectIdContents = projectId.Split('/').ToList();
                     if (projectIdContents.Count > 0)
                     {
-                        AssessmentProjectName = projectIdContents[projectIdContents.Count - 1];                        
+                        AssessmentProjectName = projectIdContents[projectIdContents.Count - 1];
                         SiteDiscoveryStatusInfoLabel.Text = "Inventory data fetched successfully";
                     }
                     else

--- a/src/Forms/ProjectDetailsForm.resx
+++ b/src/Forms/ProjectDetailsForm.resx
@@ -173,58 +173,31 @@
   <data name="&gt;&gt;AzureMigrateProjectNameInfoLabel.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="AssessmentProjectNameInfoLabel.AutoSize" type="System.Boolean, mscorlib">
+  <data name="SiteDiscoveryStatusInfoLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="AssessmentProjectNameInfoLabel.Font" type="System.Drawing.Font, System.Drawing">
+  <data name="SiteDiscoveryStatusInfoLabel.Font" type="System.Drawing.Font, System.Drawing">
     <value>Microsoft Sans Serif, 8.25pt</value>
   </data>
-  <data name="AssessmentProjectNameInfoLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>648, 311</value>
+  <data name="SiteDiscoveryStatusInfoLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>620, 312</value>
   </data>
-  <data name="AssessmentProjectNameInfoLabel.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="SiteDiscoveryStatusInfoLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>0, 13</value>
   </data>
-  <data name="AssessmentProjectNameInfoLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;AssessmentProjectNameInfoLabel.Name" xml:space="preserve">
-    <value>AssessmentProjectNameInfoLabel</value>
-  </data>
-  <data name="&gt;&gt;AssessmentProjectNameInfoLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;AssessmentProjectNameInfoLabel.Parent" xml:space="preserve">
-    <value>AzureMigrateProjectDetailsGroupBox</value>
-  </data>
-  <data name="&gt;&gt;AssessmentProjectNameInfoLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="DiscoverySiteNameInfoLabel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="DiscoverySiteNameInfoLabel.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 8.25pt</value>
-  </data>
-  <data name="DiscoverySiteNameInfoLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>512, 312</value>
-  </data>
-  <data name="DiscoverySiteNameInfoLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>0, 13</value>
-  </data>
-  <data name="DiscoverySiteNameInfoLabel.TabIndex" type="System.Int32, mscorlib">
+  <data name="SiteDiscoveryStatusInfoLabel.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
   </data>
-  <data name="&gt;&gt;DiscoverySiteNameInfoLabel.Name" xml:space="preserve">
-    <value>DiscoverySiteNameInfoLabel</value>
+  <data name="&gt;&gt;SiteDiscoveryStatusInfoLabel.Name" xml:space="preserve">
+    <value>SiteDiscoveryStatusInfoLabel</value>
   </data>
-  <data name="&gt;&gt;DiscoverySiteNameInfoLabel.Type" xml:space="preserve">
+  <data name="&gt;&gt;SiteDiscoveryStatusInfoLabel.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;DiscoverySiteNameInfoLabel.Parent" xml:space="preserve">
+  <data name="&gt;&gt;SiteDiscoveryStatusInfoLabel.Parent" xml:space="preserve">
     <value>AzureMigrateProjectDetailsGroupBox</value>
   </data>
-  <data name="&gt;&gt;DiscoverySiteNameInfoLabel.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;SiteDiscoveryStatusInfoLabel.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
   <data name="ResourceGroupNameInfoLabel.AutoSize" type="System.Boolean, mscorlib">


### PR DESCRIPTION
We enable the import scenario radio button only when the import sites are discovered, and we enable the appliance scenario radio button only when the appliance (HyperV or VMWare or Physical servers) sites are discovered.