### PR TITLE
Add UTC in LogHandler

### DIFF
--- a/src/Logger/LogHandler.cs
+++ b/src/Logger/LogHandler.cs
@@ -164,7 +164,7 @@ namespace Azure.Migrate.Explore.Logger
         private string currentTimeStamp()
         {
             DateTime now = DateTime.UtcNow;
-            return now.ToString("yyyy-MM-dd-HH:mm:ss");
+            return now.ToString("yyyy-MM-dd-HH:mm:ss 'UTC'");
         }
     }
 }


### PR DESCRIPTION
Updated the currentTimeStamp() method to include an explicit "UTC" suffix in the returned string. This makes it clear that the timestamp is in Coordinated Universal Time, thereby improving readability.