### PR TITLE
Fix nilref in parsing discovered data.

### DIFF
--- a/src/Discovery/RetrieveDiscoveryData.cs
+++ b/src/Discovery/RetrieveDiscoveryData.cs
@@ -149,8 +149,13 @@ namespace Azure.Migrate.Explore.Discovery
                 // parse IP Address and MAC Address
                 Dictionary<string, List<string>> macIpAddressMap = new Dictionary<string, List<string>>();
                 foreach (var networkAdapter in value.Properties.NetworkAdapters)
-                    if (!macIpAddressMap.ContainsKey(networkAdapter.MacAddress))
+                {
+                    if (networkAdapter.MacAddress != null && networkAdapter.IpAddressList != null &&
+                        !macIpAddressMap.ContainsKey(networkAdapter.MacAddress))
+                    {
                         macIpAddressMap.Add(networkAdapter.MacAddress, networkAdapter.IpAddressList);
+                    }
+                }
                 KeyValuePair<string, string> parsedMacIpAddressMap = ParseMacIpAddressMap(macIpAddressMap, userInputObj);
 
                 discoveryDataObj.IpAddress = parsedMacIpAddressMap.Value;


### PR DESCRIPTION
This pull request makes a targeted improvement to the parsing logic for VMware discovery data by adding null checks to ensure more robust handling of network adapter information.

**Improvement to network adapter parsing:**

* Added checks to ensure that both `MacAddress` and `IpAddressList` are not null before adding entries to the `macIpAddressMap` dictionary in `ParseVMWareDiscoveryData`. This prevents potential null reference exceptions and ensures only valid data is processed.