### PR TITLE
Include WebApp Supportability data in Excel.

### DIFF
--- a/src/Common/DiscoveryReportConstants.cs
+++ b/src/Common/DiscoveryReportConstants.cs
@@ -13,6 +13,7 @@ namespace Azure.Migrate.Explore.Common
         public const string vCenterHost_Report_TabName = "vCenter_Host_Report";
         public const string ARGDataTabName = "ARGData";
         public const string WebAppSupportabilityDataTabName = "WebAppSupportability";
+        public const string SoftwareInventoryInsightsTabName = "SoftwareInventoryInsights";
 
         public static readonly List<string> PropertiesList = new List<string>
         {

--- a/src/Discovery/Discover.cs
+++ b/src/Discovery/Discover.cs
@@ -106,12 +106,24 @@ namespace Azure.Migrate.Explore.Discovery
                 new string[] { UserInputObj.Subscription.Key },
                 allSites).GetAwaiter().GetResult();
 
+            // Fetch Software Inventory Insights.
+            var softwareInventoryInsights = ARGDataFetcher.GetSoftwareInventoryInsightsAsync(
+                UserInputObj,
+                new string[] { UserInputObj.Subscription.Key },
+                allSites).GetAwaiter().GetResult();
+
             UserInputObj.LoggerObj.LogInformation($"Retrieved discovery data for {DiscoveredData.Count.ToString()} machines");
 
             DiscoveryProperties discoveryProperties = new DiscoveryProperties();
             CreateDiscoveryPropertiesModel(discoveryProperties);
 
-            ExportDiscoveryReport exporter = new ExportDiscoveryReport(DiscoveredData, VCenterHostData, discoveryProperties, argData, webAppSupportability);
+            ExportDiscoveryReport exporter = new ExportDiscoveryReport(
+                DiscoveredData,
+                VCenterHostData,
+                discoveryProperties,
+                argData,
+                webAppSupportability,
+                softwareInventoryInsights);
             exporter.GenerateDiscoveryReportExcel();
 
             UserInputObj.LoggerObj.LogInformation(excelCreationPercentProgress, "Discovery report excel created successfully"); // IsExpressWorkflow ? 20 : 100 % Complete

--- a/src/Excel/ExportDiscoveryReport.cs
+++ b/src/Excel/ExportDiscoveryReport.cs
@@ -17,6 +17,7 @@ namespace Azure.Migrate.Explore.Excel
         private readonly vCenterHostDiscovery VCenterHostDiscoveryData;
         private readonly string DiscoveryDataFromARG;
         private readonly string WebAppSupportabilityDataFromARG;
+        private readonly string SoftwareInventoryInsights;
         XLWorkbook DiscoveryWb;
 
         public ExportDiscoveryReport(
@@ -24,13 +25,15 @@ namespace Azure.Migrate.Explore.Excel
             vCenterHostDiscovery vCenterHostData,
             DiscoveryProperties discoveryPropertiesData,
             string discoveryDataFromARG = "",
-            string webAppSupportabilityDataFromARG = "")
+            string webAppSupportabilityDataFromARG = "",
+            string softwareInventoryInsights = "")
         {
             DiscoveredData = discoveredData;
             DiscoveryPropertiesData = discoveryPropertiesData;
             VCenterHostDiscoveryData = vCenterHostData;
             DiscoveryDataFromARG = discoveryDataFromARG;
             WebAppSupportabilityDataFromARG = webAppSupportabilityDataFromARG;
+            SoftwareInventoryInsights = softwareInventoryInsights;
             DiscoveryWb = new XLWorkbook();
         }
 
@@ -41,6 +44,7 @@ namespace Azure.Migrate.Explore.Excel
             GeneratevCenterHostReportWorksheet();
             GenerateArgDataWorksheet();
             GenerateWebAppSupportabilityDataWorksheet();
+            GenerateSoftwareInventoryInsightsWorksheet();
 
             DiscoveryWb.SaveAs(UtilityFunctions.GetReportsDirectory() + "\\" + DiscoveryReportConstants.DiscoveryReportName);
         }
@@ -101,6 +105,13 @@ namespace Azure.Migrate.Explore.Excel
             UtilityFunctions.SaveARGJsonDataToWorksheet(
                 WebAppSupportabilityDataFromARG,
                 DiscoveryWb.Worksheets.Add(DiscoveryReportConstants.WebAppSupportabilityDataTabName, 5));
+        }
+
+        private void GenerateSoftwareInventoryInsightsWorksheet()
+        {
+            UtilityFunctions.SaveARGJsonDataToWorksheet(
+                SoftwareInventoryInsights,
+                DiscoveryWb.Worksheets.Add(DiscoveryReportConstants.SoftwareInventoryInsightsTabName, 6));
         }
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature that fetches and exports web application supportability data as part of the discovery report workflow. It adds logic to query, process, and include support status information for both Tomcat and IIS web applications, and outputs this data in a dedicated worksheet in the generated Excel report.

Key changes grouped by theme:

**Feature: Web Application Supportability Data Collection & Export**
* Added new Kusto queries and methods in `ARGDataFetcher` to fetch supportability status for Tomcat and IIS web applications, including logic to merge and process results.
* Integrated the fetching of web app supportability data into the discovery workflow in `Discover.cs`, and passed this data to the report exporter.
* Updated `ExportDiscoveryReport` to accept and store the web app supportability data, and added a new worksheet for this data in the generated Excel report. [[1]](diffhunk://#diff-33fcac3769ae9321b57fe52042eb17029c0b061ba1dce170b2e58c5c142e02ecR19-R33) [[2]](diffhunk://#diff-33fcac3769ae9321b57fe52042eb17029c0b061ba1dce170b2e58c5c142e02ecR43-L45) [[3]](diffhunk://#diff-33fcac3769ae9321b57fe52042eb17029c0b061ba1dce170b2e58c5c142e02ecR91-R104)

**Constants and Utility**
* Added a new constant `WebAppSupportabilityDataTabName` in `DiscoveryReportConstants` to name the new worksheet tab.
* Added necessary `using` directive for `Newtonsoft.Json.Linq` to support JSON manipulation.