### PR TITLE
Disable AI summary features and show deprecation notice

### DIFF
--- a/src/AssessmentSettings.xaml.cs
+++ b/src/AssessmentSettings.xaml.cs
@@ -820,8 +820,7 @@ namespace AzureMigrateExplore
             if (ProgressBar.Value >= 100 && !UserInputObj.WorkflowObj.IsExpressWorkflow && !string.IsNullOrEmpty(UserInputObj.WorkflowObj.Module) && UserInputObj.WorkflowObj.Module.Equals("Discovery"))
             {
                 //mainObj.MakeTrackProgressActionButtonsEnabledDecisions(true, false, false);
-                mainObj.ShowNextButton();
-                mainObj.EnableNextButton();
+                mainObj.HideNextButton();
                 mainObj.EnableProjectDetailsTabButton();
                 mainObj.EnableConfigurationTabButton();
                 mainObj.EnableAssessmentSettingsTabButton();
@@ -831,9 +830,8 @@ namespace AzureMigrateExplore
             }
             else if (ProgressBar.Value >= 100 && !UserInputObj.WorkflowObj.IsExpressWorkflow && !string.IsNullOrEmpty(UserInputObj.WorkflowObj.Module) && UserInputObj.WorkflowObj.Module.Equals("Assessment"))
             {
-                mainObj.MakeTrackProgressActionButtonsEnabledDecisions(false, false, true);
-                mainObj.ShowNextButton();
-                mainObj.EnableNextButton();
+                mainObj.MakeTrackProgressActionButtonsEnabledDecisions(false, false, false);
+                mainObj.HideNextButton();
                 mainObj.ShowProjectDetailsTabButton();
                 mainObj.EnableConfigurationTabButton();
                 mainObj.EnableAssessmentSettingsTabButton();
@@ -843,9 +841,8 @@ namespace AzureMigrateExplore
             }
             else if (ProgressBar.Value >= 100 && UserInputObj.WorkflowObj.IsExpressWorkflow)
             {
-                mainObj.MakeTrackProgressActionButtonsEnabledDecisions(false, false, true);
-                mainObj.ShowNextButton();
-                mainObj.EnableNextButton();
+                mainObj.MakeTrackProgressActionButtonsEnabledDecisions(false, false, false);
+                mainObj.HideNextButton();
                 mainObj.EnableProjectDetailsTabButton();
                 mainObj.EnableConfigurationTabButton();
                 mainObj.EnableAssessmentSettingsTabButton();

--- a/src/MainWindow.xaml
+++ b/src/MainWindow.xaml
@@ -87,17 +87,17 @@
                         <SymbolIcon Symbol="Sync"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>-->
-                <NavigationViewItem Style="{StaticResource NavigationViewItemStyle}" Content="Generate Summary with AI" Tag="CopilotQuestionnaire" x:Name="CopilotQuestionnaireTabButton">
+                <NavigationViewItem Style="{StaticResource NavigationViewItemStyle}" Content="Generate Summary with AI" Tag="CopilotQuestionnaire" x:Name="CopilotQuestionnaireTabButton" Visibility="Collapsed">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xf4a5;" FontFamily="Segoe Fluent Icons" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
-                <NavigationViewItem Style="{StaticResource NavigationViewItemStyle}" Content="Copilot Chat" Tag="CopilotChat" x:Name="CopilotChatTabButton">
+                <NavigationViewItem Style="{StaticResource NavigationViewItemStyle}" Content="Copilot Chat" Tag="CopilotChat" x:Name="CopilotChatTabButton" Visibility="Collapsed">
                     <NavigationViewItem.Icon>
                         <SymbolIcon Symbol="Message"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
-                <NavigationViewItem Style="{StaticResource NavigationViewItemStyle}" Content="Review Summary" Tag="ChatPage" x:Name="ChatPageTabButton">
+                <NavigationViewItem Style="{StaticResource NavigationViewItemStyle}" Content="Review Summary" Tag="ChatPage" x:Name="ChatPageTabButton" Visibility="Collapsed">
                     <NavigationViewItem.Icon>
                         <SymbolIcon Symbol="VideoChat"/>
                     </NavigationViewItem.Icon>
@@ -138,7 +138,7 @@
                 <Button Style="{StaticResource PrimaryButtonStyle}" Content="Stop" Click="StopButton_Click" x:Name="StopButton" Height="40" Width="100"/>
                 <Button Style="{StaticResource PrimaryButtonStyle}" Content="Retry" Click="RetryButton_Click" x:Name="RetryButton" Height="40" Width="100"/>
                 <Button Style="{StaticResource PrimaryButtonStyle}" Content="Assess" Click="AssessButton_Click" x:Name="AssessButton" Height="40" Width="100"/>
-                <Button Style="{StaticResource PrimaryButtonStyle}" Content="Summarize with AI" Click="GenerateSummaryButton_Click" Name="GenerateSummaryButton" Height="40" Width="150"/>
+                <Button Style="{StaticResource PrimaryButtonStyle}" Content="Summarize with AI" Click="GenerateSummaryButton_Click" Name="GenerateSummaryButton" Height="40" Width="150" Visibility="Collapsed"/>
             </StackPanel>
             <Button Style="{StaticResource PrimaryButtonStyle}" Content="Next" Click="NextButton_Click" Visibility="Collapsed" x:Name="NextButton" Height="40" Width="100" Grid.Column="2"/>
         </Grid>

--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -115,8 +115,10 @@ namespace AzureMigrateExplore
             var dialog = new ContentDialog
             {
                 Title = "Azure Migrate Export - Deprecation Notice",
-                Content = "The Azure Migrate Export tool will be deprecated on 30th June. " +
-                          "A better and more robust experience is available on the Azure portal under the \"Reports\" heading.",
+                Content = "The Azure Migrate Export GitHub utility will be deprecated on June 30, 2026. " +
+                          "The capability is now built right into the Azure Migrate portal, so you no longer need to run a tool to get your executive report. " +
+                          "Just log-on to your Azure Migrate project, go to Manage > Reports, and generate the executive report directly from the portal. " +
+                          "If you have questions or need help making the switch, reach out to the Azure Support <amesupport@microsoft.com>.",
                 CloseButtonText = "OK",
                 DefaultButton = ContentDialogButton.Close,
                 XamlRoot = this.Content.XamlRoot

--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -64,6 +64,8 @@ namespace AzureMigrateExplore
 
         private Stopwatch stopwatch = new Stopwatch();
 
+        private static bool _deprecationNoticeShown = false;
+
         public MainWindow()
         {
             this.InitializeComponent();
@@ -89,11 +91,44 @@ namespace AzureMigrateExplore
 
                 var VersionLabel = GetVersion();
                 NavView.PaneTitle = "Azure Migrate Explore\n" + VersionLabel;
+
+                this.Loaded += MainWindow_Loaded;
             }
             catch (Exception ex)
             {
                 DisplayAlert("Initialization Error", $"An error occurred during initialization: {ex.Message}", "OK");
                 CloseForm();
+            }
+        }
+
+        private async void MainWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (_deprecationNoticeShown)
+                return;
+            _deprecationNoticeShown = true;
+
+            await ShowDeprecationNoticeAsync();
+        }
+
+        private async Task ShowDeprecationNoticeAsync()
+        {
+            var dialog = new ContentDialog
+            {
+                Title = "Azure Migrate Export - Deprecation Notice",
+                Content = "The Azure Migrate Export tool will be deprecated on 30th June. " +
+                          "A better and more robust experience is available on the Azure portal under the \"Reports\" heading.",
+                CloseButtonText = "OK",
+                DefaultButton = ContentDialogButton.Close,
+                XamlRoot = this.Content.XamlRoot
+            };
+
+            try
+            {
+                await dialog.ShowAsync();
+            }
+            catch
+            {
+                // If the dialog cannot be shown (e.g., XamlRoot not ready), fail silently.
             }
         }
         private string GetVersion()
@@ -1288,7 +1323,8 @@ namespace AzureMigrateExplore
 
         public void ShowGenerateSummaryButton()
         {
-            GenerateSummaryButton.Visibility = Visibility.Visible;
+            // AI summary feature disabled; keep the button hidden.
+            GenerateSummaryButton.Visibility = Visibility.Collapsed;
         }
 
         public void HideGenerateSummaryButton()

--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -1420,7 +1420,8 @@ namespace AzureMigrateExplore
 
         public void ShowCopilotQuestionnaireTabButton()
         {
-            CopilotQuestionnaireTabButton.Visibility = Visibility.Visible;
+            // Tab is permanently hidden
+            CopilotQuestionnaireTabButton.Visibility = Visibility.Collapsed;
         }
 
         public void HideCopilotQuestionnaireTabButton()


### PR DESCRIPTION
- Hide Copilot/AI navigation items and 'Summarize with AI' button in MainWindow.xaml

- Hide the Next button and disable AI summary trigger after assessment completion

- Show a deprecation notice dialog on app load informing users the tool will be deprecated on 30th June and pointing to the Azure portal Reports experience