### PR TITLE
Add network assessment creation support

### DIFF
--- a/src/HttpRequestHelper/AssessmentArmTemplate.json
+++ b/src/HttpRequestHelper/AssessmentArmTemplate.json
@@ -239,6 +239,49 @@
     {
       "apiVersion": "2025-09-09-preview",
       "properties": {
+        "assessmentArmIds": [
+          "[concat(parameters('assessmentProjectId'), '/assessments/', parameters('assessmentName'), '-vm')]"
+        ],
+        "settings": {
+          "sizingCriterion": "[parameters('sizingCriterion')]",
+          "environmentType": "[parameters('environmentType')]",
+          "azureLocation": "[parameters('azureLocation')]",
+          "currency": "[parameters('currency')]",
+          "azureSecurityOfferingType": "NO",
+          "discountPercentage": "[parameters('discountPercentage')]",
+          "billingSettings": {
+            "licensingProgram": "[parameters('billingLicensingProgram')]",
+            "subscriptionId": "[if(equals(parameters('billingSubscriptionId'), ''), json('null'), parameters('billingSubscriptionId'))]"
+          },
+          "savingsSettings": {
+            "savingsOptions": "[parameters('savingsOptions')]"
+          },
+          "performanceData": {},
+          "scalingFactor": 1,
+          "networkSettings": {
+            "includePlatformNetworkComponents": true,
+            "useWafAndCafForNetworkDesign": true,
+            "mimicOnPremNetwork": true
+          }
+        },
+        "details": {
+          "status": "Created"
+        },
+        "scope": {
+          "azureResourceGraphQuery": "[variables('azureResourceGraphQuery')]",
+          "scopeType": "AzureResourceGraphQuery"
+        }
+      },
+      "dependsOn": [
+        "[concat(parameters('assessmentProjectId'), '/assessments/', parameters('assessmentName'), '-vm')]"
+      ],
+      "id": "[concat(parameters('assessmentProjectId'), '/networkAssessments/', parameters('assessmentName'), '-network')]",
+      "name": "[concat(parameters('assessmentProjectName'), '/', parameters('assessmentName'), '-network')]",
+      "type": "Microsoft.Migrate/assessmentprojects/networkAssessments"
+    },
+    {
+      "apiVersion": "2025-09-09-preview",
+      "properties": {
         "settings": {
           "appSvcContainerSettings": {
             "isolationRequired": false

--- a/src/HttpRequestHelper/HttpClientHelper.cs
+++ b/src/HttpRequestHelper/HttpClientHelper.cs
@@ -573,6 +573,17 @@ namespace Azure.Migrate.Explore.HttpRequestHelper
                         props["assessmentArmIds"] = prunedList;
                     }
                 }
+
+                // Handle networkAssessments
+                if (res.Value<string>("type")?.ToLowerInvariant().EndsWith("/networkassessments") == true)
+                {
+                    JObject props = (JObject)res["properties"];
+                    if (props?["assessmentArmIds"] is JArray armIds)
+                    {
+                        JArray prunedList = new JArray(armIds.Where(a => keptIds.Contains(a.ToString())));
+                        props["assessmentArmIds"] = prunedList;
+                    }
+                }
             }
 
             // Replace filtered resources in template


### PR DESCRIPTION
Adds network assessment resources to the ARM deployment template and prunes their assessmentArmIds during scope filtering so creation works when network is in scope.